### PR TITLE
Allow optional directory argument in pull

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,15 +133,16 @@ async function pull(argv) {
     }
     var user = argv[0].split('/')[0];
     var repl = argv[0].split('/')[1];
+    var dir = argv[1] || repl;
 
-    fs.mkdir(repl, function (err) {
+    fs.mkdir(dir, function (err) {
         if (err) throw err;
     });
 
     await download(`https://repl.it/@${user}/${repl}.zip`, `${repl}/${repl}.zip`);
 
     var zip = new AdmZip(`${repl}/${repl}.zip`);
-    zip.extractAllTo(repl, true);
+    zip.extractAllTo(dir, true);
     fs.unlink(`${repl}/${repl}.zip`, function (err) {
         if (err) throw err;
     });


### PR DESCRIPTION
In `git clone`, you can optionally pass a directory as a second argument which is what inspired this. 